### PR TITLE
Travis CI: Do not hard-code Trusty, it EOLs this month

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 ---
-dist: trusty
 cache: pip
 language: java
 services:


### PR DESCRIPTION
Do not hard-code __Trusty__ because it reaches its end-of-life this month.
https://wiki.ubuntu.com/Releases